### PR TITLE
MTE-5238: Remove underline on focus state

### DIFF
--- a/src/scss/overview.scss
+++ b/src/scss/overview.scss
@@ -40,6 +40,10 @@
   grid-gap: 10px;
   grid-template-columns: repeat(2, 1fr);
 
+  &:focus {
+    text-decoration: none;
+  }
+
   &:hover {
     box-shadow: 0 0 16px -1px rgba(0, 0, 0, .2);
     text-decoration: none;


### PR DESCRIPTION
This PR fixes a bug with the focus state on solve links.
Relates to: rackerlabs/zoolander#732