### PR TITLE
MTE-5196: Add method test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "postversion": "git push && git push --tags",
     "start": "gulp & npm run dev",
     "test": "karma start --single-run",
-    "lint:js": "eslint --ext .js, src",
+    "lint:js": "eslint --ext .js, src test",
+    "lint:js:fix": "eslint --ext .js, src test --fix && npm run lint:js",
     "lint:sass": "sass-lint -v",
     "build": "node build/build.js"
   },

--- a/src/pages/solve-overview/index.js
+++ b/src/pages/solve-overview/index.js
@@ -28,6 +28,7 @@ export default Vue.component('solve-overview-content', {
         trimmed: content ? content.slice(0, this.visibleContent) : [],
         full: content || [],
         total,
+        featured: Math.min(articles, total),
       };
     },
     viewAction() {
@@ -88,9 +89,7 @@ export default Vue.component('solve-overview-content', {
       let data = {};
       if (this.$env === 'development') {
         data = await new Promise((resolve) => {
-          setTimeout(() => {
-            resolve(mockCategories);
-          }, 1000);
+          resolve(mockCategories);
         });
       } else {
         const resp = await axios({
@@ -127,9 +126,7 @@ export default Vue.component('solve-overview-content', {
       let data = {};
       if (this.$env === 'development') {
         data = await new Promise((resolve) => {
-          setTimeout(() => {
-            resolve(mockData);
-          }, 2000);
+          resolve(mockData);
         });
       } else {
         const resp = await axios({
@@ -147,10 +144,23 @@ export default Vue.component('solve-overview-content', {
         return c - d;
       }).reverse();
     },
+    getContent() {
+      return this.content;
+    },
+    getFilteredContentCount() {
+      return this.filteredContent.full.length;
+    },
+    getVisibleContentCount() {
+      return this.visibleContent;
+    },
+    incrementVisibleContent() {
+      const itemsLeft = this.getFilteredContentCount() - this.getVisibleContentCount();
+      this.visibleContent += (itemsLeft > this.moreAmount) ? this.moreAmount : itemsLeft;
+    },
     loadMore() {
-      const num = this.visibleContent;
-      if (num < this.filteredContent.full.length) {
-        this.visibleContent += this.moreAmount;
+      const num = this.getVisibleContentCount();
+      if (num < this.getFilteredContentCount()) {
+        this.incrementVisibleContent();
       }
     },
     getDateString(isoDate) {

--- a/test/solve-overview.spec.js
+++ b/test/solve-overview.spec.js
@@ -1,33 +1,197 @@
 import { expect } from 'chai';
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import Strings from '@/filters/strings';
 import Solve from '../src/pages/solve-overview/';
 
-describe('getGridStyles', () => {
+const localVue = createLocalVue();
+localVue.filter('translate', Strings.translate);
+localVue.filter('truncate', Strings.truncate);
+localVue.prototype.$env = 'development';
+
+describe('Solve', () => {
   beforeEach(() => {
-    this.wrapper = shallowMount(Solve);
+    this.wrapper = shallowMount(Solve, { localVue });
+    window.rsSolveFilterTopic = undefined;
+    window.Drupal = {
+      t: string => string,
+    };
   });
 
-  it('returns {1,1} for index 0', () => {
-    expect(this.wrapper.vm.getGridStyles(0)).to.eql({ 'grid-row': 1, 'grid-column': 1 });
+  describe('computed', () => {
+    describe('filteredContent', () => {
+      it('loads all content and has two featured items when no filter is present', async () => {
+        await this.wrapper.vm.getData();
+        expect(this.wrapper.vm.filteredContent.total).to.eql(12);
+        expect(this.wrapper.vm.filteredContent.featured).to.eql(2);
+      });
+
+      it('loads only filtered content and only has one featured item when a filter is present', async () => {
+        window.rsSolveFilterTopic = '269';
+        await this.wrapper.vm.getData();
+        expect(this.wrapper.vm.filteredContent.total).to.eql(10);
+        expect(this.wrapper.vm.filteredContent.featured).to.eql(1);
+      });
+
+      it('loads nothing when filter is invalid', async () => {
+        window.rsSolveFilterTopic = '999';
+        await this.wrapper.vm.getData();
+        expect(this.wrapper.vm.filteredContent.total).to.eql(0);
+        expect(this.wrapper.vm.filteredContent.featured).to.eql(0);
+      });
+    });
+
+    describe('viewAction', () => {
+      it('returns expected values', () => {
+        expect(this.wrapper.vm.viewAction).to.eql({
+          Video: 'watch',
+          Article: 'read',
+          Podcast: 'listen',
+          Infographic: 'read',
+        });
+      });
+    });
+
+    describe('ctaText', () => {
+      it('returns expected values', () => {
+        expect(this.wrapper.vm.ctaText).to.eql({
+          Video: 'Watch the Video',
+          Article: 'Read the Article',
+          Podcast: 'Listen Now',
+          Infographic: 'Read Now',
+        });
+      });
+    });
   });
 
-  it('returns {1,2} for index 1', () => {
-    expect(this.wrapper.vm.getGridStyles(1)).to.eql({ 'grid-row': 1, 'grid-column': 2 });
-  });
+  describe('methods', () => {
+    describe('getGridStyles', () => {
+      it('returns {1,1} for index 0', () => {
+        expect(this.wrapper.vm.getGridStyles(0)).to.eql({ 'grid-row': 1, 'grid-column': 1 });
+      });
 
-  it('returns {2,1} for index 2', () => {
-    expect(this.wrapper.vm.getGridStyles(2)).to.eql({ 'grid-row': 2, 'grid-column': 1 });
-  });
+      it('returns {1,2} for index 1', () => {
+        expect(this.wrapper.vm.getGridStyles(1)).to.eql({ 'grid-row': 1, 'grid-column': 2 });
+      });
 
-  it('returns {2,2} for index 3', () => {
-    expect(this.wrapper.vm.getGridStyles(3)).to.eql({ 'grid-row': 2, 'grid-column': 2 });
-  });
+      it('returns {2,1} for index 2', () => {
+        expect(this.wrapper.vm.getGridStyles(2)).to.eql({ 'grid-row': 2, 'grid-column': 1 });
+      });
 
-  it('returns {3,1} for index 4', () => {
-    expect(this.wrapper.vm.getGridStyles(4)).to.eql({ 'grid-row': 3, 'grid-column': 1 });
-  });
+      it('returns {2,2} for index 3', () => {
+        expect(this.wrapper.vm.getGridStyles(3)).to.eql({ 'grid-row': 2, 'grid-column': 2 });
+      });
 
-  it('returns {3,2} for index 5', () => {
-    expect(this.wrapper.vm.getGridStyles(5)).to.eql({ 'grid-row': 3, 'grid-column': 2 });
+      it('returns {3,1} for index 4', () => {
+        expect(this.wrapper.vm.getGridStyles(4)).to.eql({ 'grid-row': 3, 'grid-column': 1 });
+      });
+
+      it('returns {3,2} for index 5', () => {
+        expect(this.wrapper.vm.getGridStyles(5)).to.eql({ 'grid-row': 3, 'grid-column': 2 });
+      });
+    });
+
+    describe('formatDate', () => {
+      it('returns properly formatted date when passed a Date object', () => {
+        const date = new Date('2017-06-11 03:30:30');
+        expect(this.wrapper.vm.formatDate(date)).to.eql('June 11, 2017');
+      });
+
+      it('throws TypeError when passed a string', () => {
+        const date = '2017-06-11 03:30:30';
+        expect(() => { this.wrapper.vm.formatDate(date); })
+          .to.throw('date.getDate is not a function');
+      });
+    });
+
+    describe('getDateString', () => {
+      it('returns properly formatted date when passed a Date object', () => {
+        const date = new Date('2017-06-11 03:30:30');
+        expect(this.wrapper.vm.getDateString(date)).to.eql('June 11, 2017');
+      });
+
+      it('returns properly formatted date when passed a string', () => {
+        const date = '2017-06-11 03:30:30';
+        expect(this.wrapper.vm.getDateString(date)).to.eql('June 11, 2017');
+      });
+    });
+
+    describe('fetchData', () => {
+      it('retrieves 12 results', () => this.wrapper.vm.fetchData().then((data) => {
+        expect(data.length).to.eql(12);
+        expect(data[0].title).to.eql('Thought Leadership: Sample');
+        expect(data[10].field_author).to.eql('Mike Rustyellow');
+      }));
+    });
+
+    describe('visibleContent', () => {
+      it('is initially set to 4', () => {
+        expect(this.wrapper.vm.getVisibleContentCount()).to.eql(4);
+      });
+
+      it('increments by 4 until it has no more results to load', async () => {
+        window.rsSolveFilterTopic = '269';
+        await this.wrapper.vm.getData();
+        expect(this.wrapper.vm.getVisibleContentCount()).to.eql(4);
+        this.wrapper.vm.loadMore();
+        expect(this.wrapper.vm.getVisibleContentCount()).to.eql(8);
+        this.wrapper.vm.loadMore();
+        expect(this.wrapper.vm.getVisibleContentCount()).to.eql(9);
+        this.wrapper.vm.loadMore();
+        expect(this.wrapper.vm.getVisibleContentCount()).to.eql(9);
+      });
+    });
+
+    describe('filteredContent', () => {
+      it('initially contains 10 items by default', async () => {
+        await this.wrapper.vm.getData();
+        expect(this.wrapper.vm.getFilteredContentCount()).to.equal(10);
+      });
+
+      it('contains 9 items when filter is changed', async () => {
+        window.rsSolveFilterTopic = '272';
+        await this.wrapper.vm.getData();
+        expect(this.wrapper.vm.getFilteredContentCount()).to.equal(9);
+      });
+
+      it('contains 0 items when filter is invalid', async () => {
+        window.rsSolveFilterTopic = '499';
+        await this.wrapper.vm.getData();
+        expect(this.wrapper.vm.getFilteredContentCount()).to.equal(0);
+      });
+    });
+
+    describe('sortData', () => {
+      it('sorts array of objects by field_published_date', async () => {
+        this.wrapper.vm.content = [
+          {
+            title: 'A',
+            field_published_date: '2019-10-01T11:20:57-05:00',
+          },
+          {
+            title: 'B',
+            field_published_date: '2019-11-01T11:20:57-05:00',
+          },
+          {
+            title: 'C',
+            field_published_date: '2019-09-01T11:20:57-05:00',
+          },
+        ];
+        this.wrapper.vm.sortData();
+        const content = this.wrapper.vm.getContent();
+        expect(content[0].title).to.eql('B');
+        expect(content[1].title).to.eql('A');
+        expect(content[2].title).to.eql('C');
+      });
+    });
+
+    describe('getCategories', () => {
+      it('retrieves 5 results', () => this.wrapper.vm.getCategories().then((cats) => {
+        expect(cats.length).to.eql(5);
+        expect(cats[1].name).to.eql('Innovation');
+        expect(cats[1].tid).to.eql('269');
+        expect(cats[4].name).to.eql('What Are You Solving For?');
+        expect(cats[4].tid).to.eql('273');
+      }));
+    });
   });
 });


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/MTE-5196

package.json:
  - Added `test` folder into lint scope as well
  - Added `lint:js:fix` script as a convenience to automagically fix linting errors. 

src/filters/strings.js:
  - If `Drupal` is undefined (which happens in tests), just return string by itself.

src/pages/solve-overview/index.js
  - I removed the `setTimeout` on retrieval of mock data to make developer experience faster.
  - Added `getContent()` which is useful in tests to retrieve the full content.
  - Added `getFilteredContentCount()` which retrieves a count of items in the full filtered content list
  - Added `getVisibleContentCount()` which retrieves a count of items currently visible
  - Added `incrementVisibleCount()` which increases the number of visible items by 4, or however many items are left if less than 4.
  - Modified `loadMore()` to use above methods 

test/solve-overview.spec.js
  - Wrapped the entire file with a separate `Solve` test block
  - Clear out `window.rsSolveFilterTopic` before each test
  - Created test blocks for `computed` and `methods`, with the respective tests going into each block.
  - Added tests for the `filteredContent` computed property
  - Added tests for the `viewAction` computed property
  - Added tests for the `ctaText` computed property
  - Added tests for the `formatDate` method
  - Added tests for the `getDateString` method
  - Added test for the `fetchData` method to confirm we were able to retrieve data from our mock
  - Added tests related to the visible content counters and load more buttons
  - Added tests for the filtered content, specifically when you change filters out 
  - Added test for the `sortData` method to confirm it sorts things as expected
  - Added test for the `getCategories` method to ensure we could retrieve category data as expected.