### PR TITLE
MTE-5485: Solve Category Pages Has Extra Gray Space

### DIFF
--- a/src/scss/overview.scss
+++ b/src/scss/overview.scss
@@ -9,7 +9,7 @@
 }
 
 .rsTl-topic-section {
-  margin-bottom: 35px;
+  padding-bottom: 35px;
 }
 
 .rsTl-feature-header {


### PR DESCRIPTION
https://jira.rax.io/browse/MTE-5485

- removing this class so that the "gray space is not there"