### PR TITLE
MTE-7198: Fix the sticky to only look at normal articles

### DIFF
--- a/src/pages/solve-overview/index.js
+++ b/src/pages/solve-overview/index.js
@@ -123,11 +123,7 @@ export default Vue.component('solve-overview-content', {
         this.content = await this.fetchData();
         await this.filterByTopic();
         this.sortData();
-        // if there is a pinned article present, we need to move it to the top
-        const pinned = _.findIndex(this.content, { sticky: 'True' });
-        if (pinned >= 0) {
-          this.content.splice(0, 0, this.content.splice(pinned, 1)[0]);
-        }
+
         const normalList = [];
         const podcasts = [];
         // here we can group content separately
@@ -143,6 +139,11 @@ export default Vue.component('solve-overview-content', {
             normalList.push(item);
           }
         });
+        // if there is a pinned article present, we need to move it to the top
+        const pinned = _.findIndex(normalList, { sticky: 'True' });
+        if (pinned >= 0) {
+          normalList.splice(0, 0, normalList.splice(pinned, 1)[0]);
+        }
         this.content = normalList;
         this.podcasts = podcasts;
         // if there is no topic filter then we need the featured header


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/MTE-7198

This PR adds a separate sticky check for articles vs podcasts, since they're separated into separate lists. 

This prevents sticky podcasts from interfering with the sequence of regular articles and vice versa. 